### PR TITLE
Separate the release and upload step as subcommands

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    install_requires=['twine'],
+    install_requires=['click', 'twine'],
     entry_points={
         'console_scripts': ['pyreleaser = pyreleaser.cli:main'],
     },

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -13,7 +13,7 @@ def git(path, *args):
 @pytest.fixture
 def cmd(repo):
     def func(*args, **kwargs):
-        process = run(['pyreleaser', *args], cwd=repo, **kwargs)
+        process = run(['pyreleaser', *args], cwd=repo, stdout=PIPE, stderr=PIPE, **kwargs)
         return process
     return func
 
@@ -62,33 +62,39 @@ def project(repo):
 
 
 def test_usage(cmd):
-    proc = cmd(stdout=PIPE, stderr=PIPE)
-    assert b'arguments are required' in proc.stderr
+    proc = cmd()
+    assert b'Usage: pyreleaser' in proc.stdout
 
 
 def test_no_setuppy(cmd, repo):
-    proc = cmd('1.0', stdout=PIPE, stderr=PIPE)
+    proc = cmd('create', '1.0')
     assert b'missing setup.py file' in proc.stderr
 
 
 def test_local_tag_exists(cmd, repo):
-    proc = cmd('0.1', stdout=PIPE, stderr=PIPE)
+    proc = cmd('create', '0.1')
     assert b'tag already exists locally' in proc.stderr
 
 
 def test_remote_tag_exists(cmd, repo):
-    proc = cmd('0.2', stdout=PIPE, stderr=PIPE)
+    proc = cmd('create', '0.2')
     assert b'tag already exists remotely' in proc.stderr
 
 
 def test_version_already_in_setuppy(cmd, repo, project):
-    proc = cmd('0.0', stdout=PIPE, stderr=PIPE)
+    proc = cmd('create', '0.0')
     assert proc.returncode == 1
     assert b'already the current version' in proc.stderr
 
 
+def test_branch_check(cmd, repo, project):
+    proc = cmd('create', '0.0', '--only-on', 'wrongbranch')
+    assert proc.returncode == 1
+    assert b'not on the wrongbranch branch' in proc.stderr
+
+
 def test_run(cmd, repo, project):
-    proc = cmd('1.0', stdout=PIPE, stderr=PIPE)
+    proc = cmd('create', '1.0')
     assert proc.returncode == 0
     assert proc.stderr == b''
 
@@ -97,3 +103,28 @@ def test_run(cmd, repo, project):
 
     tags = git(repo, 'tag').stdout.split(b'\n')
     assert b'v1.0' in tags
+
+
+def test_upload_usage(cmd):
+    proc = cmd('upload', '--help')
+    assert b'Usage: pyreleaser' in proc.stdout
+
+
+def test_upload(cmd, repo, project):
+    proc = cmd('upload', '--dry-run')
+
+    assert proc.returncode == 0
+    assert proc.stderr == b''
+
+    assert repo.join('dist', 'test-0.0.tar.gz').exists()
+    assert repo.join('dist', 'test-0.0-py3-none-any.whl').exists()
+
+
+def test_upload_setuppy_error(cmd, repo, project):
+    repo.join('setup.py').write('raise Exception("TESTERROR")')
+
+    proc = cmd('upload', '--dry-run')
+
+    assert proc.returncode == 1
+    assert b'failed to build distribution' in proc.stderr
+    assert b'TESTERROR' in proc.stdout


### PR DESCRIPTION
```bash
$ pyreleaser create 0.4.1
🔸  Update version in setup.py
🔸  Commit the release
[refactor-2 7f42389] Release v0.4.1
 1 file changed, 1 insertion(+), 1 deletion(-)
🔸  Tag the release: v0.4.1

🔔  Don't forget to push with: git push --follow-tags
```

```bash
$ pyreleaser upload --dry-run
🔸  Build distributions
🔸  Upload to PyPI
Not running: ['twine', 'upload', 'dist/*']
```


```bash
$ pyreleaser upload --dry-run
🔸  Build distributions
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: invalid command 'bdist_wheel'

Error: failed to build distribution
```